### PR TITLE
add minimal docker compose setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+#Pre-build stage
+FROM golang:1.21-bookworm AS pre-build
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN mkdir "/build"
+
+WORKDIR "/build/"
+# Get dependencies in a layer so rebuilds are faster
+COPY go.mod . 
+COPY go.sum .
+RUN go mod download
+
+# Build the base application
+COPY . /build/
+RUN go build ./cmd/mycolog
+
+#just in case, make the binaries executable
+RUN <<EOT bash 
+    chmod +x /build/mycolog
+EOT
+
+# post copying / run stage, should only rerun if scripts or bins change
+FROM debian:12-slim
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN mkdir "/scripts" && mkdir "/temp"
+COPY --from=pre-build "/build/mycolog" "/usr/bin/"
+COPY "mycolog.sh" "/scripts"
+COPY "docker-entrypoint.sh" "/scripts"
+
+WORKDIR "/scripts"
+ENTRYPOINT ["/bin/bash", "./docker-entrypoint.sh"]
+CMD ["./mycolog.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+---
+services:
+  mycolog:
+    build:
+      context: .
+      dockerfile: ./Dockerfile
+    ports:
+      - "8080:8080"
+    environment:
+      - XDG_DATA_HOME=${HOME}/.local/share/mycolog
+    volumes:
+      - ${HOME}/.local/share/mycolog:${HOME}/.local/share/mycolog:rw

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+set -e #exit on error
+exec "$@"

--- a/mycolog.sh
+++ b/mycolog.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+echo "binary location debug information"
+export MYCOLOG_BIN_LOC=$(which mycolog)
+echo "running mycolog from: $MYCOLOG_BIN_LOC"
+mycolog


### PR DESCRIPTION
Hi, found this while browsing around for a tool like this and have in my fork a setup with this to build and run it under docker compose. Since it's a simple webui, it works pretty easily to run it this way.

I know it's a totally unprompted PR so of course feel free to reject or suggest changes, but I thought why not I'll share :shrug: 

A few points:
- don't know exactly if it's cross platform ish, since I don't have a mac or windows machine to test on
- added entrypoint sh to run and execute, in case functionality expands and needs flags or checks
- I mapped the data storage location as `~/.local/share/mycolog` since I don't think it would be so good to map in the whole `~/.local/share` to the container

runs with `docker-compose up` or `docker compose up`